### PR TITLE
Hack to fix bonus challenge state being retained on canceling level load (fixed)

### DIFF
--- a/game/mod_hl2/gamepadui/schemebonusbutton.res
+++ b/game/mod_hl2/gamepadui/schemebonusbutton.res
@@ -1,0 +1,93 @@
+"Scheme"
+{
+	"BaseSettings"
+	{
+		"Button.Width.Out"						"200"
+		"Button.Width.Over"						"200"
+		"Button.Width.Pressed"					"200"
+
+		"Button.Medal.Size"					"32"
+		"Button.Medal.OffsetX"				"164"
+		"Button.Medal.OffsetY"				"4"
+
+		"Button.Height.Out"						"137"
+		"Button.Height.Over"					"137"
+		"Button.Height.Pressed"					"137"
+		"Button.Progress.Height"				"2"
+
+		"Button.Text.OffsetX.Out"					"0"
+		"Button.Text.OffsetX.Over"					"0"
+		"Button.Text.OffsetX.Pressed"				"0"
+		"Button.Text.OffsetY.Out"					"55"
+		"Button.Text.OffsetY.Over"					"55"
+		"Button.Text.OffsetY.Pressed"				"55"
+
+		"Button.Description.OffsetX.Out"			"0"
+		"Button.Description.OffsetY.Out"			"1"
+		"Button.Description.OffsetX.Over"			"0"
+		"Button.Description.OffsetY.Over"			"1"
+		"Button.Description.OffsetX.Pressed"		"0"
+		"Button.Description.OffsetY.Pressed"		"1"
+
+		"Button.Description.Hide.Out"				"1"
+		"Button.Description.Hide.Over"				"1"
+		"Button.Description.Hide.Pressed"			"1"
+
+		"Button.Animation.Width"					"0.15"
+		"Button.Animation.Height"					"0.25"
+		"Button.Animation.Background"				"0.2"
+		"Button.Animation.Text"					"0.2"
+		"Button.Animation.Description"			"0.3"
+
+		"FooterButtons.OffsetX"					"64"
+		"FooterButtons.OffsetY"					"48"
+
+		"Button.Text.CenterX"					"1"
+	}
+
+	"Colors"
+	{
+		"Button.Background.Out"						"0 0 0 0"
+		"Button.Background.Over"					"255 255 255 255"
+		"Button.Background.Pressed"					"255 255 255 255"
+		"Button.Background.Progress"				"61 189 237 255"
+
+		"Button.Text.Out"							"255 255 255 150"
+		"Button.Text.Over"							"0 0 0 255"
+		"Button.Text.Pressed"						"0 0 0 255"
+
+		"Button.Description.Out"					"0 0 0 0"
+		"Button.Description.Over"					"0 0 0 255"
+		"Button.Description.Pressed"				"0 0 0 255"
+	}
+
+	"Fonts"
+	{
+		"Button.Text.Font"
+		{
+			"settings"
+			{
+				"name"			"Noto Sans"
+				"tall"			"16" // 19
+				"weight"		"750" // 400
+				"antialias"		"1"
+			}
+		}
+		"Button.Text.Font.Small"
+		{
+			"settings"
+			{
+				"name"			"Noto Sans"
+				"tall"			"14"
+				"weight"		"600"
+				"antialias"		"1"
+			}
+		}
+	}
+
+	"CustomFontFiles"
+	{
+		"file"		"gamepadui/fonts/NotoSans-Regular.ttf"
+		"file"		"gamepadui/fonts/din1451alt.ttf"
+	}
+}

--- a/game/mod_hl2/gamepadui/schemepanel.res
+++ b/game/mod_hl2/gamepadui/schemepanel.res
@@ -152,6 +152,17 @@
 				"antialias"		"1"
 			}
 		}
+
+		"BonusDesc.Font"
+		{
+			"settings"
+			{
+				"name"			"Noto Sans"
+				"tall"			"13"
+				"weight"		"400"
+				"antialias"		"1"
+			}
+		}
 	}
 
 	"CustomFontFiles"

--- a/game/mod_portal/gamepadui/schemebonusbutton.res
+++ b/game/mod_portal/gamepadui/schemebonusbutton.res
@@ -68,8 +68,18 @@
 			"settings"
 			{
 				"name"			"Noto Sans"
-				"tall"			"19"
-				"weight"		"400"
+				"tall"			"16" // 19
+				"weight"		"750" // 400
+				"antialias"		"1"
+			}
+		}
+		"Button.Text.Font.Small"
+		{
+			"settings"
+			{
+				"name"			"Noto Sans"
+				"tall"			"14"
+				"weight"		"600"
 				"antialias"		"1"
 			}
 		}

--- a/game/mod_portal/gamepadui/schemepanel.res
+++ b/game/mod_portal/gamepadui/schemepanel.res
@@ -152,6 +152,17 @@
 				"antialias"		"1"
 			}
 		}
+
+		"BonusDesc.Font"
+		{
+			"settings"
+			{
+				"name"			"Noto Sans"
+				"tall"			"13"
+				"weight"		"400"
+				"antialias"		"1"
+			}
+		}
 	}
 
 	"CustomFontFiles"

--- a/src/game/gamepadui/gamepadui_mainmenu.cpp
+++ b/src/game/gamepadui/gamepadui_mainmenu.cpp
@@ -164,6 +164,17 @@ void GamepadUIMainMenu::OnCommand( char const* pCommand )
         const char* pszClientCmd = &pCommand[ 4 ];
         if ( *pszClientCmd )
             GamepadUI::GetInstance().GetEngineClient()->ClientCmd_Unrestricted( pszClientCmd );
+
+        // This is a hack to reset bonus challenges in the event that the player disconnected before the map loaded.
+        // We have no known way of detecting that event and differentiating between a bonus level and non-bonus level being loaded,
+        // so for now, we just reset this when the player presses any menu button, as that indicates they are in the menu and no longer loading a bonus level
+        // (note that this does not cover loading a map through other means, like through the console)
+        ConVarRef sv_bonus_challenge( "sv_bonus_challenge" );
+        if (sv_bonus_challenge.GetInt() != 0)
+        {
+            GamepadUI_Log( "Resetting sv_bonus_challenge\n" );
+            sv_bonus_challenge.SetValue( 0 );
+        }
     }
     else
     {


### PR DESCRIPTION
Fixes conflicts from https://github.com/entropy-zero/HL2-GamepadUI/pull/16